### PR TITLE
Fixed not secure browser url issue

### DIFF
--- a/app/controllers/embed/pages_controller.rb
+++ b/app/controllers/embed/pages_controller.rb
@@ -77,13 +77,13 @@ class Embed::PagesController < ApplicationController
     @holes.each do |hole|
       gon.hole_num << hole.hole_num if hole.video.present?
       gon.videos << hole.video  if hole.video.present?
-      gon.videos_urls << hole.video.video.url(resolution).gsub('s3-us-west-2.amazonaws.com/fore92', 'd1s5na5d5z3eyp.cloudfront.net') if hole.video.present?
+      gon.videos_urls << hole.video.video.url(resolution).gsub('s3-us-west-2.amazonaws.com/fore92', 'd1s5na5d5z3eyp.cloudfront.net').gsub("http", "https") if hole.video.present?
       gon.tags << hole.video.tags  if hole.video.present?
       gon.par << hole.par if hole.video.present?
       gon.yard << hole.yards if hole.video.present?
       gon.mhcp << hole.mhcp if hole.video.present?
       gon.image << hole.image_file_name if hole.video.present?
-      gon.image_urls << hole.image.url.gsub('s3-us-west-2.amazonaws.com/fore92', 'd1s5na5d5z3eyp.cloudfront.net') if hole.video.present?
+      gon.image_urls << hole.image.url.gsub('s3-us-west-2.amazonaws.com/fore92', 'd1s5na5d5z3eyp.cloudfront.net').gsub("http", "https") if hole.video.present?
     end
     @videos_urls = gon.videos_urls
   end
@@ -95,8 +95,8 @@ class Embed::PagesController < ApplicationController
     @course = Course.find(params[:id])
     resolution = (is_mobile? ? 'mobile' : 'medium').to_sym
     @course.playlist_items.each do |video|
-      gon.videos_urls << video.video.url(resolution).gsub('s3-us-west-2.amazonaws.com/fore92', 'd1s5na5d5z3eyp.cloudfront.net') if video.video.present?
-      gon.image_urls << video.thumbnail_image.url.gsub('s3-us-west-2.amazonaws.com/fore92', 'd1s5na5d5z3eyp.cloudfront.net') if video.thumbnail_image.present?
+      gon.videos_urls << video.video.url(resolution).gsub('s3-us-west-2.amazonaws.com/fore92', 'd1s5na5d5z3eyp.cloudfront.net').gsub("http", "https") if video.video.present?
+      gon.image_urls << video.thumbnail_image.url.gsub('s3-us-west-2.amazonaws.com/fore92', 'd1s5na5d5z3eyp.cloudfront.net').gsub("http", "https") if video.thumbnail_image.present?
     end
     @videos_urls = gon.videos_urls
     @holes = @course.holes.order("hole_num")


### PR DESCRIPTION
The issue with the generated URL for the Erin Hills videos has been addressed. Previously, it was utilizing "http" instead of "https". This issue has now been resolved, and the URLs have been updated accordingly.